### PR TITLE
fix: local & remote payouts batch dlc txs

### DIFF
--- a/include/cfddlcjs/cfddlcjs_struct.h
+++ b/include/cfddlcjs/cfddlcjs_struct.h
@@ -146,6 +146,7 @@ struct AddSignaturesToRefundTxResponseStruct {
 struct CreateBatchDlcTransactionsRequestStruct {
   std::vector<int64_t> local_payouts;                    //!< local_payouts  // NOLINT
   std::vector<int64_t> remote_payouts;                   //!< remote_payouts  // NOLINT
+  std::vector<int64_t> num_payouts;                      //!< num_payouts  // NOLINT
   std::vector<std::string> local_fund_pubkeys;           //!< local_fund_pubkeys  // NOLINT
   std::vector<std::string> local_final_script_pubkeys;   //!< local_final_script_pubkeys  // NOLINT
   std::vector<std::string> remote_fund_pubkeys;          //!< remote_fund_pubkeys  // NOLINT

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ export interface AddSignatureToFundTransactionResponse {
 export interface CreateBatchDlcTransactionsRequest {
     localPayouts: (bigint | number)[];
     remotePayouts: (bigint | number)[];
+    numPayouts: (bigint | number)[];
     localFundPubkeys: string[];
     localFinalScriptPubkeys: string[];
     remoteFundPubkeys: string[];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfd-dlc-js",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "cfd-dlc node.js api",
   "domain": "atomicfinance",
   "main": "index.js",

--- a/src/autogen/cfd_dlc_js_api_json_autogen.cpp
+++ b/src/autogen/cfd_dlc_js_api_json_autogen.cpp
@@ -466,6 +466,13 @@ void CreateBatchDlcTransactionsRequest::CollectFieldName() {
   json_mapper.emplace("remotePayouts", func_table);
   item_list.push_back("remotePayouts");
   func_table = {
+    CreateBatchDlcTransactionsRequest::GetNumPayoutsString,
+    CreateBatchDlcTransactionsRequest::SetNumPayoutsString,
+    CreateBatchDlcTransactionsRequest::GetNumPayoutsFieldType,
+  };
+  json_mapper.emplace("numPayouts", func_table);
+  item_list.push_back("numPayouts");
+  func_table = {
     CreateBatchDlcTransactionsRequest::GetLocalFundPubkeysString,
     CreateBatchDlcTransactionsRequest::SetLocalFundPubkeysString,
     CreateBatchDlcTransactionsRequest::GetLocalFundPubkeysFieldType,
@@ -618,6 +625,7 @@ void CreateBatchDlcTransactionsRequest::ConvertFromStruct(
     const CreateBatchDlcTransactionsRequestStruct& data) {
   local_payouts_.ConvertFromStruct(data.local_payouts);
   remote_payouts_.ConvertFromStruct(data.remote_payouts);
+  num_payouts_.ConvertFromStruct(data.num_payouts);
   local_fund_pubkeys_.ConvertFromStruct(data.local_fund_pubkeys);
   local_final_script_pubkeys_.ConvertFromStruct(
       data.local_final_script_pubkeys);
@@ -648,6 +656,7 @@ CreateBatchDlcTransactionsRequestStruct CreateBatchDlcTransactionsRequest::Conve
   CreateBatchDlcTransactionsRequestStruct result;
   result.local_payouts = local_payouts_.ConvertToStruct();
   result.remote_payouts = remote_payouts_.ConvertToStruct();
+  result.num_payouts = num_payouts_.ConvertToStruct();
   result.local_fund_pubkeys = local_fund_pubkeys_.ConvertToStruct();
   result.local_final_script_pubkeys = local_final_script_pubkeys_.ConvertToStruct();  // NOLINT
   result.remote_fund_pubkeys = remote_fund_pubkeys_.ConvertToStruct();

--- a/src/autogen/cfd_dlc_js_api_json_autogen.h
+++ b/src/autogen/cfd_dlc_js_api_json_autogen.h
@@ -1948,6 +1948,50 @@ class CreateBatchDlcTransactionsRequest
   }
 
   /**
+   * @brief Get of numPayouts.
+   * @return numPayouts
+   */
+  JsonValueVector<int64_t>& GetNumPayouts() {  // NOLINT
+    return num_payouts_;
+  }
+  /**
+   * @brief Set to numPayouts.
+   * @param[in] num_payouts    setting value.
+   */
+  void SetNumPayouts(  // line separate
+      const JsonValueVector<int64_t>& num_payouts) {  // NOLINT
+    this->num_payouts_ = num_payouts;
+  }
+  /**
+   * @brief Get data type of numPayouts.
+   * @return Data type of numPayouts.
+   */
+  static std::string GetNumPayoutsFieldType() {
+    return "JsonValueVector<int64_t>";  // NOLINT
+  }
+  /**
+   * @brief Get json string of numPayouts field.
+   * @param[in,out] obj     class object
+   * @return JSON string.
+   */
+  static std::string GetNumPayoutsString(  // line separate
+      const CreateBatchDlcTransactionsRequest& obj) {  // NOLINT
+    // Do not set to const, because substitution of member variables
+    // may occur in pre / post processing inside Serialize
+    return obj.num_payouts_.Serialize();
+  }
+  /**
+   * @brief Set json object to numPayouts field.
+   * @param[in,out] obj     class object
+   * @param[in] json_value  JSON object
+   */
+  static void SetNumPayoutsString(  // line separate
+      CreateBatchDlcTransactionsRequest& obj,  // NOLINT
+      const UniValue& json_value) {
+    obj.num_payouts_.DeserializeUniValue(json_value);
+  }
+
+  /**
    * @brief Get of localFundPubkeys.
    * @return localFundPubkeys
    */
@@ -2939,6 +2983,10 @@ class CreateBatchDlcTransactionsRequest
    * @brief JsonAPI(remotePayouts) value
    */
   JsonValueVector<int64_t> remote_payouts_;  // NOLINT
+  /**
+   * @brief JsonAPI(numPayouts) value
+   */
+  JsonValueVector<int64_t> num_payouts_;  // NOLINT
   /**
    * @brief JsonAPI(localFundPubkeys) value
    */

--- a/src/input_json_format/cfddlcapi_create_batch_dlc_transactions.json
+++ b/src/input_json_format/cfddlcapi_create_batch_dlc_transactions.json
@@ -5,6 +5,7 @@
     ":class:comment": "Create Batch Dlc transactions",
     "localPayouts": [0],
     "remotePayouts": [0],
+    "numPayouts": [0],
     "localFundPubkeys": [""],
     "localFinalScriptPubkeys": [""],
     "remoteFundPubkeys": [""],

--- a/wrap_js/__test__/CreateBatchDlcTransactions.spec.ts
+++ b/wrap_js/__test__/CreateBatchDlcTransactions.spec.ts
@@ -8,8 +8,9 @@ function GetRequest(
   remoteChange = 4899999789
 ) {
   return {
-    localPayouts: [TestData.WinAmount, TestData.LoseAmount],
-    remotePayouts: [TestData.LoseAmount, TestData.WinAmount],
+    localPayouts: [TestData.WinAmount, TestData.LoseAmount, TestData.WinAmount, TestData.LoseAmount],
+    remotePayouts: [TestData.LoseAmount, TestData.WinAmount, TestData.LoseAmount, TestData.WinAmount],
+    numPayouts: [2, 2],
     localFundPubkeys: [TestData.LocalFundPubkey, TestData.LocalFundPubkey2],
     remoteFundPubkeys: [TestData.RemoteFundPubkey, TestData.RemoteFundPubkey2],
     localInputAmount: TestData.LocalInputAmount,
@@ -62,6 +63,8 @@ const testCase = [
       cetsHexList: [
         TestData.CetBatchHex,
         TestData.CetBatchHex2,
+        TestData.CetBatchHex,
+        TestData.CetBatchHex2,
       ],
       refundTxHexList: [TestData.RefundBatchTransaction, TestData.RefundBatchTransaction2],
     }
@@ -72,14 +75,14 @@ const errorCase = [
   TestHelper.createTestCase(
     "CreateBatchDlcTransactions invalid Pubkey",
     cfddlcjs.CreateBatchDlcTransactions,
-    { ...GetRequest(), localFundPubkeys: [""] },
-    TestHelper.createIllegalArgumentError("Vector sizes do not match the number of pubkeys or fund_output_serial_ids is not empty and does not match the number of pubkeys.")
+    { ...GetRequest(), localFundPubkeys: ["", ""] },
+    TestHelper.createIllegalArgumentError("Invalid Pubkey data.")
   ),
   TestHelper.createTestCase(
     "CreateBatchDlcTransactions invalid hex string(3 chars)",
     cfddlcjs.CreateBatchDlcTransactions,
-    { ...GetRequest(), localFundPubkeys: ["000"] },
-    TestHelper.createIllegalArgumentError("Vector sizes do not match the number of pubkeys or fund_output_serial_ids is not empty and does not match the number of pubkeys.")
+    { ...GetRequest(), localFundPubkeys: ["000", "000"] },
+    TestHelper.createIllegalArgumentError("hex to byte convert error.")
   ),
 ];
 


### PR DESCRIPTION
## What 

Fix local and remote payouts conversion for `CreateBatchDlcTransactions`

## Why 

Previously, it was equally splitting the payouts, but it should be splitting based on the number of payouts for each DLC