### PR TITLE
downgrade: cfd-js from v0.4.12 to v0.3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/node": "^24.0.12",
         "@typescript-eslint/eslint-plugin": "^4.22.1",
         "@typescript-eslint/parser": "^4.22.1",
-        "cfd-js": "github:atomicfinance/cfd-js#v0.4.12",
+        "cfd-js": "github:atomicfinance/cfd-js#v0.3.13",
         "cross-env": "^7.0.3",
         "eslint": "^6.5.1",
         "eslint-config-google": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@types/node": "^24.0.12",
     "@typescript-eslint/eslint-plugin": "^4.22.1",
     "@typescript-eslint/parser": "^4.22.1",
-    "cfd-js": "github:atomicfinance/cfd-js#v0.4.12",
+    "cfd-js": "github:atomicfinance/cfd-js#v0.3.13",
     "cross-env": "^7.0.3",
     "eslint": "^6.5.1",
     "eslint-config-google": "^0.14.0",


### PR DESCRIPTION
## What

Downgrade cfd-js from v0.4.12 to v0.3.13

## Why

To ensure no issues with updated 0.4.12 API which cfd-dlc-js is not updated for

Reverts https://github.com/AtomicFinance/cfd-dlc-js/pull/41